### PR TITLE
Assign: app.locals.__name as meta.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ module.exports = options => {
 			authS3O(req, res, next)
 		});
 	}
+
+	app.locals.__name = meta.name;
+
 	// to avoid errors
 	app.locals.origami = {};
 	return app;


### PR DESCRIPTION
Needs to be set so that it can be read by [HTML files](https://github.com/Financial-Times/n-internal-tool/blob/master/layouts/wrapper.html#L11).