### PR TITLE
Don't run S30 auth on double-underscore routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,9 @@ module.exports = options => {
 		app.use((req, res, next) => {
 			if (req.url.indexOf('/__') === 0) {
 				next()
+			} else {
+				authS3O(req, res, next)
 			}
-			authS3O(req, res, next)
 		});
 	}
 


### PR DESCRIPTION
Fixes https://sentry.io/nextftcom/ft-next-dni-topics/issues/210660930/

@andygout, @wheresrhys 