### PR TITLE
Display: Favicon on all pages

### DIFF
--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,0 +1,1 @@
+<link rel="icon" type="image/png" href="https://www.ft.com/__assets/creatives/brand-ft/icons/v2/favicon-32x32.png" sizes="32x32">

--- a/layouts/vanilla.html
+++ b/layouts/vanilla.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8">
 		<title>{{#title}}{{{this}}}{{/title}}</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		{{>favicon}}
 		<link rel="stylesheet" href="/{{__name}}/main.css">
 		{{#outputBlock 'head'}}{{/outputBlock}}
 	</head>

--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -7,6 +7,7 @@
 		<style>
 			html, body {margin: 0; padding: 0;}
 		</style>
+		{{>favicon}}
 		<link rel="stylesheet" href="//www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header-services@^1.1.0{{#if origami.css}},{{origami.css}}{{/if}}">
 		<link rel="stylesheet" href="/{{__name}}/main.css">
 		{{#outputBlock 'head'}}{{/outputBlock}}


### PR DESCRIPTION
Currently only displays favicon for root URL of app (not sure how it is getting it even then): this applies it for all pages.