### PR TITLE
Renamed to s3o-middleware to @financial-times/s3o-middleware 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@financial-times/n-express": "^19.2.2",
     "@financial-times/n-handlebars": "^1.17.9",
-    "s3o-middleware": "^1.8.0"
+    "@financial-times/s3o-middleware": "^2.0.4"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.8.16",


### PR DESCRIPTION
Fixed: warning s3o-middleware@1.8.0: This has be renamed to @financial-times/s3o-middleware. Please change to @financial-times/s3o-middleware to receives updates to this module.