### PR TITLE
o-header-services major version bump

### DIFF
--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -8,7 +8,7 @@
 			html, body {margin: 0; padding: 0;}
 		</style>
 		{{>favicon}}
-		<link rel="stylesheet" href="//www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header-services@^1.1.0{{#if origami.css}},{{origami.css}}{{/if}}">
+		<link rel="stylesheet" href="//www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header-services@^2.0.0{{#if origami.css}},{{origami.css}}{{/if}}">
 		<link rel="stylesheet" href="/{{__name}}/main.css">
 		{{#outputBlock 'head'}}{{/outputBlock}}
 	</head>
@@ -18,7 +18,7 @@
 			{{{body}}}
 		</main>
 		{{>drawer}}
-		<script src="//www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header-services@^1.1.0{{#if origami.js}},{{origami.js}}{{/if}}&amp;autoinit=1"></script>
+		<script src="//www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header-services@^2.0.0{{#if origami.js}},{{origami.js}}{{/if}}&amp;autoinit=1"></script>
 		<script src="/{{__name}}/main.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
o-header-services - Required at version ^1.1.0 in the URL - Required at version ^2.0.0 by o-techdocs@^7.0.0