### PR TITLE
Bump n-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-internal-tool#readme",
   "dependencies": {
-    "@financial-times/n-express": "^19.20.2",
+    "@financial-times/n-express": "^19.21.4",
     "@financial-times/n-handlebars": "^1.19.1",
     "@financial-times/s3o-middleware": "^3.0.0"
   },


### PR DESCRIPTION
To stop Heroku using cached version of next-metrics