### PR TITLE
Remove s3o middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Simple nodejs server intended for internal, web-based tools
 * n-express - next's standard issue server, with error-handling, metrics, utility endpoints (e.g. /__about) and healthchecks built in
 * n-handlebars - handlebarsjs with a few additional helpers introduced by next
 * o-header-services - origami header for non user-facing websites
-* s3o-middleware - integrate with FT's single sign on by default
 
 
 ## Options
@@ -17,7 +16,6 @@ Simple nodejs server intended for internal, web-based tools
 - `options.helpers` - map of handlebars helpers
 - `options.systemCode` - system code for the app
 - `options.healthchecks` - array of healthchecks for the app (see n-express for details)
-- `options.s3o` - whether to use single sign-on middleware (default `true`)
 - `options.extname` - file extension of files to use as handlebars templates (default: `'.html'`)
 
 
@@ -25,10 +23,9 @@ Simple nodejs server intended for internal, web-based tools
 * `Router` - Next's Express router
 * `static` - common static data
 * `metrics` - Next metrics
-* `authS3O` - FT's single sign as middleware
 
 ```js
-import authS3O from `@financial-times/n-internal-tool`;
+import express from `@financial-times/n-internal-tool`;
 ```
 
 ## Data model

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 const nExpress = require('@financial-times/n-express');
 const nHandlebars = require('@financial-times/n-handlebars');
-const authS3O = require('@financial-times/s3o-middleware');
-
 const path = require('path');
 
 const handlebars = function ({app, directory, options}) {
@@ -25,13 +23,13 @@ const handlebars = function ({app, directory, options}) {
 		helpers: options.helpers || {},
 		directory: directory,
 		viewsDirectory: viewsDirectory
-	})
-}
+	});
+};
 
 module.exports = options => {
 	options = options || {};
 
-	const {app, meta, addInitPromise} = nExpress.getAppContainer(options)
+	const {app, meta, addInitPromise} = nExpress.getAppContainer(options);
 
 	addInitPromise(handlebars({
 		app,
@@ -40,24 +38,14 @@ module.exports = options => {
 	}));
 
 	app.use('/' + meta.name, nExpress.static(meta.directory + '/public', { redirect: false }));
-	if (options.s3o !== false) {
-		app.use((req, res, next) => {
-			if (req.url.indexOf('/__') === 0) {
-				next()
-			} else {
-				authS3O(req, res, next)
-			}
-		});
-	}
 
 	app.locals.__name = meta.name;
 
 	// to avoid errors
 	app.locals.origami = {};
 	return app;
-}
+};
 
 module.exports.Router = nExpress.Router;
 module.exports.static = nExpress.static;
 module.exports.metrics = nExpress.metrics;
-module.exports.authS3O = authS3O;

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/Financial-Times/n-internal-tool#readme",
   "dependencies": {
     "@financial-times/n-express": "^19.21.4",
-    "@financial-times/n-handlebars": "^2.0.0",
-    "@financial-times/s3o-middleware": "^3.0.0"
+    "@financial-times/n-handlebars": "^2.0.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
The s3o option of n-internal-tools is not being used by any Next app.
All apps dependent on n-internal-tools are setting the s3o option to
false and implementing their own auth using the s3o-middleware directly.

I talked to @sjparkinson and we decided it might be best to rip out the
auth option from n-internal-tools and have each app implement their own
Okta auth as they were doing previously with s3o.

Totally open to discussion though, what do you think?