### PR TITLE
Add .o-grid-container--snappy class

### DIFF
--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -14,7 +14,7 @@
 	</head>
 	<body>
 		{{>header}}
-		<main class="o-grid-container">
+		<main class="o-grid-container o-grid-container--snappy">
 			{{{body}}}
 		</main>
 		{{>drawer}}


### PR DESCRIPTION
As per the [`n-ui-foundations` v5 to v6 Migration Guide](https://github.com/Financial-Times/n-ui-foundations#user-content-migration-guides), the following must be applied to `.o-grid-container` elements.

```diff
-<div class="o-grid-container"></div>
+<div class="o-grid-container o-grid-container--snappy"></div>
```

While this component does not use `n-ui-foundations` itself, other components consume both this component and `n-ui-foundations`, but the code for the `.o-grid-container` element they use are in this repo, and so it must be updated here.

The consuming components/apps are responsible for acquiring the requisite `o-grid` classes, and so this change need not (in fact cannot as there are no `.scss` files) be applied here:

```diff
-@include oGridContainer();
+@include oGridContainer($grid-mode: 'snappy');
```

#### Example:
[n-profile-ui](https://github.com/Financial-Times/n-profile-ui/pull/79) uses `n-ui-foundations` and has demos which uses `n-internal-tool` for their layout.

This will be released as a major breaking change.