### PR TITLE
CPP-60 n-handlebars-removal

### DIFF
--- a/handlebars/express-handlebars.js
+++ b/handlebars/express-handlebars.js
@@ -63,5 +63,3 @@ const applyToExpress = function (app, options) {
 };
 
 module.exports = applyToExpress;
-module.exports.handlebars = handlebars;
-module.exports.standalone = nextifyHandlebars;

--- a/handlebars/express-handlebars.js
+++ b/handlebars/express-handlebars.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Path = require('path');
+const path = require('path');
 const expressHandlebars = require('express-handlebars');
 const handlebars = require('./handlebars');
 const extendHelpers = require('./extend-helpers');
@@ -26,7 +26,7 @@ const nextifyHandlebars = function (options) {
 	});
 
 	const partialsDir = (options.partialsDir || []);
-	const dependencyRoot = Path.join(options.directory, '/bower_components/');
+	const dependencyRoot = path.join(options.directory, '/bower_components/');
 	const ignoreListInLinkedDeps = ['.git', 'node_modules', 'bower_components', 'demos'];
 	const limitToComponents = (options.limitToComponents || '');
 

--- a/handlebars/express-handlebars.js
+++ b/handlebars/express-handlebars.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const Path = require('path');
+const expressHandlebars = require('express-handlebars');
+const handlebars = require('./handlebars');
+const extendHelpers = require('./extend-helpers');
+const loadPartials = require('./load-partials');
+
+const nextifyHandlebars = function (options) {
+	if (!options || !options.directory) {
+		throw 'n-handlebars requires an options object containing a directory property';
+	}
+	const configuredHandlebars = handlebars({
+		helpers: options.helpers
+	});
+
+	const helpers = extendHelpers(options.helpers);
+
+	const expressHandlebarsInstance = new expressHandlebars.create({ // eslint-disable-line
+		// use a handlebars instance we have direct access to so we can expose partials
+		handlebars: configuredHandlebars,
+		extname: options.extname || '.html',
+		helpers: helpers,
+		defaultLayout: options.defaultLayout || false,
+		layoutsDir: options.layoutsDir || undefined
+	});
+
+	const partialsDir = (options.partialsDir || []);
+	const dependencyRoot = Path.join(options.directory, '/bower_components/');
+	const ignoreListInLinkedDeps = ['.git', 'node_modules', 'bower_components', 'demos'];
+	const limitToComponents = (options.limitToComponents || '');
+
+	// look up templates on our own to avoid scanning thousands of files
+	return loadPartials(expressHandlebarsInstance, dependencyRoot, partialsDir, ignoreListInLinkedDeps, limitToComponents)
+		.then(function (partials) {
+			expressHandlebarsInstance.partialsDir = partials;
+
+			// makes the usePartial helper possible
+			return expressHandlebarsInstance.getPartials()
+				.then(function (partials) {
+					configuredHandlebars.partials = partials;
+
+					return expressHandlebarsInstance;
+				});
+		});
+};
+
+const applyToExpress = function (app, options) {
+	if (!app) {
+		throw 'n-handlebars requires an instance of an express app';
+	}
+
+	return nextifyHandlebars(options)
+		.then(function (expressHandlebarsInstance) {
+			app.set('views', options.directory + (options.viewsDirectory || '/views'));
+
+			app.engine((options.extname || '.html'), expressHandlebarsInstance.engine);
+
+			app.set('view engine', (options.extname || '.html'));
+
+			return expressHandlebarsInstance;
+		});
+};
+
+module.exports = applyToExpress;
+module.exports.handlebars = handlebars;
+module.exports.standalone = nextifyHandlebars;

--- a/handlebars/extend-helpers.js
+++ b/handlebars/extend-helpers.js
@@ -1,0 +1,44 @@
+function deprecate (helper) {
+	return function (...args) {
+		if (process.env.NODE_ENV !== 'production') {
+			// eslint-disable-next-line no-console
+			console.warn(`The Handlebars helper ${helper.name} has been deprecated. Please talk to the Core UI team if you need to use it in your application templates. If you are not using this helper it may be used by a dependency, in which case you can ignore this warning.`);
+		}
+
+		return Reflect.apply(helper, this, args);
+	};
+}
+
+module.exports = function (helpers) {
+	helpers = helpers || {};
+
+	helpers.paragraphs = deprecate(require('./helpers/paragraphs'));
+	helpers.removeImageTags = deprecate(require('./helpers/removeImageTags'));
+	helpers.ifEquals = require('./helpers/ifEquals');
+	helpers.ifEqualsSome = deprecate(require('./helpers/ifEqualsSome'));
+	helpers.ifAll = require('./helpers/ifAll');
+	helpers.ifSome = require('./helpers/ifSome');
+	helpers.ifBool = deprecate(require('./helpers/ifBool'));
+	helpers.ifTypeof = deprecate(require('./helpers/ifTypeof'));
+	helpers.unlessAll = require('./helpers/unlessAll');
+	helpers.unlessEquals = require('./helpers/unlessEquals');
+	helpers.dateformat = require('./helpers/dateformat');
+	helpers.resize = require('./helpers/resize');
+	helpers.encode = require('./helpers/encode');
+	helpers.decodeHtmlEntities = deprecate(require('./helpers/decodeHtmlEntities'));
+	helpers.defineBlock = require('./helpers/defineBlock');
+	helpers.outputBlock = require('./helpers/outputBlock');
+	helpers.slice = require('./helpers/slice');
+	helpers.increment = deprecate(require('./helpers/increment'));
+	helpers.json = require('./helpers/json');
+	helpers.concat = require('./helpers/concat');
+	helpers.usePartial = require('./helpers/usePartial');
+	helpers.presenter = deprecate(require('./helpers/presenter'));
+	helpers.debug = deprecate(require('./helpers/debug'));
+	helpers.array = require('./helpers/array');
+	helpers.inline = deprecate(require('./helpers/inline'));
+	helpers.buildLink = deprecate(require('./helpers/buildLink'));
+	helpers.nImagePresenter = require('@financial-times/n-image/src/handlebars-helpers/nImagePresenter');
+
+	return helpers;
+};

--- a/handlebars/handlebars.js
+++ b/handlebars/handlebars.js
@@ -1,0 +1,16 @@
+/*jshint node:true*/
+'use strict';
+
+const Handlebars = require('handlebars');
+const extendHelpers = require('./extend-helpers');
+
+module.exports = function (options) {
+	options = options || {};
+
+	const helpers = extendHelpers(options.helpers);
+
+	const handlebars = Handlebars;
+	handlebars.registerHelper(helpers);
+
+	return handlebars;
+};

--- a/handlebars/helpers/array.js
+++ b/handlebars/helpers/array.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function () {
+	const args = [].slice.call(arguments);
+	return args.slice(0, -1);
+};

--- a/handlebars/helpers/buildLink.js
+++ b/handlebars/helpers/buildLink.js
@@ -1,0 +1,10 @@
+const { URL } = require('url');
+
+module.exports = function buildLink (url, queryParams = {}) {
+	if (!url) return '';
+	const urlObject = new URL(url);
+	Object.keys(queryParams).forEach(key => {
+		urlObject.searchParams.set(key, queryParams[key]);
+	});
+	return urlObject.href;
+};

--- a/handlebars/helpers/concat.js
+++ b/handlebars/helpers/concat.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+	return Array.prototype.slice.call(arguments, 0, -1).join('');
+};

--- a/handlebars/helpers/dateformat.js
+++ b/handlebars/helpers/dateformat.js
@@ -1,0 +1,21 @@
+/* eslint no-console: 0 */
+'use strict';
+
+const dateFormat = require('dateformat');
+
+module.exports = function (format, options) {
+	try {
+		if (typeof format !== 'string') {
+			options = format;
+			format = 'isoUtcDateTime';
+		}
+		if (format === 'isoDateTime' || format === 'isoUtcDateTime') {
+			format = 'isoUtcDateTime';
+			return dateFormat(options.fn(this), format, true);
+		}
+		return dateFormat(options.fn(this), format);
+	} catch(err) {
+		console.log(err);
+		return '';
+	}
+};

--- a/handlebars/helpers/debug.js
+++ b/handlebars/helpers/debug.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// credit: http://blog.teamtreehouse.com/handlebars-js-part-3-tips-and-tricks
+
+module.exports = function debug (optionalValue) {
+	/* eslint no-console: 0 */
+	console.log('Current Context');
+	console.log('====================');
+	console.log(this);
+	if (optionalValue) {
+		console.log('Value');
+		console.log('====================');
+		console.log(optionalValue);
+	}
+};

--- a/handlebars/helpers/decodeHtmlEntities.js
+++ b/handlebars/helpers/decodeHtmlEntities.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Decodes HTML entities that don't fall under the usual unsafe list
+// i.e. for decoding characters that aren't &,<,>,",',`
+module.exports = function decodeHtmlEntities (str) {
+	let key;
+	const decodeMap = {
+		'&nbsp;': ' '
+	};
+
+	for (key in decodeMap) {
+		if (decodeMap.hasOwnProperty(key)) {
+			str = str.replace(new RegExp(key, 'g'), decodeMap[key]);
+		}
+	}
+	return str;
+};

--- a/handlebars/helpers/defineBlock.js
+++ b/handlebars/helpers/defineBlock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (name, opts) {
+	if (!this.blocks) {
+		this.blocks = {};
+	}
+	if (!this.blocks[name]) {
+		this.blocks[name] = [];
+	}
+	this.blocks[name].push(opts.fn(this));
+};

--- a/handlebars/helpers/encode.js
+++ b/handlebars/helpers/encode.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function encode (str, opts) {
+
+	// nice to add hml encoding eventually, but non-trivial to do (most js solutions online are either
+	// obviously incomplete or depend on the DOM. Will add when we need {{{}}} takes care of most (?all) needs)
+	// if (opts.mode === 'html') {
+	//     return str.replace()
+	// } else
+	if (opts.hash.mode === 'uriComponent') {
+		return encodeURIComponent(str);
+	} else if (opts.hash.mode === 'uri') {
+		return encodeURI(str);
+	} else {
+		return encodeURIComponent(str);
+	}
+};

--- a/handlebars/helpers/ifAll.js
+++ b/handlebars/helpers/ifAll.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function () {
+
+	const args = [].slice.call(arguments);
+	const opts = args.pop();
+
+	return args.some(function (arg) {
+		return !arg;
+	}) ? opts.inverse(this) : opts.fn(this);
+};

--- a/handlebars/helpers/ifBool.js
+++ b/handlebars/helpers/ifBool.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const compiledExpressions = {};
+
+function compile (expression) {
+	if (!/^((\$\d)| |(&&)|(\|\|)|\)|\()+$/.test(expression)) {
+		throw 'Unsafe expression passed to isBool helper';
+	}
+
+	if (expression.length > 20) {
+		throw 'Unsafe expression passed to isBool helper (only short strings allowed because http://www.jsfuck.com/)';
+	}
+	return new Function('variables', `return !!(${expression.replace(/\$(\d)/g, ($0, $1) => `variables[${$1}]`)})`);
+}
+
+module.exports = function ifBool () {
+
+	const variables = [].slice.call(arguments);
+	const opts = variables.pop();
+	const expression = variables.pop();
+	const compiledExpression = compiledExpressions[expression] || (compiledExpressions[expression] = compile(expression));
+	return compiledExpression(variables) ? opts.fn(this) : opts.inverse(this) ;
+};

--- a/handlebars/helpers/ifEquals.js
+++ b/handlebars/helpers/ifEquals.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function (a, b, options) {
+	if (a === b) {
+		return options.fn(this);
+	}
+	return options.inverse(this);
+};

--- a/handlebars/helpers/ifEqualsSome.js
+++ b/handlebars/helpers/ifEqualsSome.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function ifEqualsSome () {
+
+	const args = [].slice.call(arguments);
+	const opts = args.pop();
+	const value = args.shift();
+
+	return args.some(function (arg) {
+		return value === arg;
+	}) ? opts.fn(this) : opts.inverse(this) ;
+};

--- a/handlebars/helpers/ifSome.js
+++ b/handlebars/helpers/ifSome.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function () {
+
+	const args = [].slice.call(arguments);
+	const opts = args.pop();
+
+	return args.some(function (arg) {
+		return arg;
+	}) ? opts.fn(this) : opts.inverse(this) ;
+};

--- a/handlebars/helpers/ifTypeof.js
+++ b/handlebars/helpers/ifTypeof.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function ifTypeof (object, type, options) {
+	if (typeof object === type) {
+		return options.fn(this);
+	}
+	return options.inverse(this);
+};

--- a/handlebars/helpers/increment.js
+++ b/handlebars/helpers/increment.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function increment (incrementBy, options) {
+	return parseInt(options.fn(this)) + incrementBy;
+};

--- a/handlebars/helpers/inline.js
+++ b/handlebars/helpers/inline.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function inline (opts) {
+	if (!opts || !opts.hash || !opts.hash.file) {
+		throw new Error('file option is mandatory');
+	}
+	const file = opts.hash.file;
+	return fs.readFileSync(path.join(process.cwd(), 'bower_components', file), 'utf-8');
+};

--- a/handlebars/helpers/json.js
+++ b/handlebars/helpers/json.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (obj) {
+	if (process.env.NODE_ENV !== 'development' && Object(obj) === obj && obj.hasOwnProperty('_locals')) {
+		throw Error('For security reasons you may not use the Handlebars JSON helper to output the entire view context');
+	}
+
+	return JSON.stringify(obj);
+};

--- a/handlebars/helpers/outputBlock.js
+++ b/handlebars/helpers/outputBlock.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function (name, opts) {
+	if (!this.blocks) {
+		this.blocks = {};
+	}
+
+	const val = this.blocks[name] && this.blocks[name].length > 0 ? this.blocks[name].join(' ') : opts.fn(this);
+
+	//precaution to avoid content set once from overriding default for future instances.
+	//not sure if this ever could happen, but I have a hunch doing this is a good idea - RE
+	delete this.blocks[name];
+	return val;
+};

--- a/handlebars/helpers/paragraphs.js
+++ b/handlebars/helpers/paragraphs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function paragraphs (input, options) {
+
+	const text = input instanceof Array ? input.join('') : input;
+	const paras = text.split('</p>');
+	const start = options.hash.start || 0;
+	const end = options.hash.end || paras.length;
+
+	return paras.slice(start, end).filter(function (p) {
+		return p.length > 0;
+	}).concat(['']).join('</p>');
+};

--- a/handlebars/helpers/presenter.js
+++ b/handlebars/helpers/presenter.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('path');
+const Handlebars = require('handlebars');
+
+module.exports = function presenter (presenterPath, context, options) {
+	const presenterName = path.basename(presenterPath).replace(/-([a-z])/g, g => g[1].toUpperCase());
+	let Presenter;
+	if (presenterPath.startsWith('.')) {
+		Presenter = require(path.join(process.cwd(), presenterPath));
+	} else {
+		Presenter = require(path.join(process.cwd(), 'bower_components', presenterPath));
+	}
+	if (options.data) {
+		if (options.hash) Object.assign(context, options.hash);
+		const data = Handlebars.createFrame(options.data);
+		data[presenterName] = new Presenter(context);
+		return options.fn(context, {data});
+	}
+};

--- a/handlebars/helpers/removeImageTags.js
+++ b/handlebars/helpers/removeImageTags.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function removeImageTags (options) {
+	return options.fn(this).replace(/<img[^>]+>/g, '');
+};

--- a/handlebars/helpers/resize.js
+++ b/handlebars/helpers/resize.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function (width, options) {
+	return 'https://www.ft.com/__origami/service/image/v2/images/raw/' + encodeURIComponent(options.fn(this)) + '?width=' + width + '&source=next&fit=scale-down';
+};

--- a/handlebars/helpers/slice.js
+++ b/handlebars/helpers/slice.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function (context, block) {
+	let ret = '';
+	if (!context || !Array.isArray(context)) {
+		return ret;
+	}
+	const offset = parseInt(block.hash.offset) || 0;
+	const limit = parseInt(block.hash.limit) || 5;
+	let i = offset;
+	const j = ((limit + offset) < context.length) ? (limit + offset) : context.length;
+
+	for (i, j; i<j; i++) {
+		ret += block.fn(context[i]);
+	}
+
+	return ret;
+};

--- a/handlebars/helpers/unlessAll.js
+++ b/handlebars/helpers/unlessAll.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function () {
+
+	const args = [].slice.call(arguments);
+	const opts = args.pop();
+
+	return args.some(function (arg) {
+		return arg;
+	}) ? opts.inverse(this) : opts.fn(this);
+};

--- a/handlebars/helpers/unlessEquals.js
+++ b/handlebars/helpers/unlessEquals.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function (a, b, options) {
+	if (a !== b) {
+		return options.fn(this);
+	}
+	return options.inverse(this);
+};

--- a/handlebars/helpers/usePartial.js
+++ b/handlebars/helpers/usePartial.js
@@ -1,0 +1,13 @@
+'use strict';
+const path = require('path');
+const handlebars = require('handlebars');
+
+module.exports = function (name, opts) {
+	if(opts.hash.path){
+		name = path.join(opts.hash.path, name);
+	}
+	if (!handlebars.partials[name]) {
+		throw new Error(`missing handlebars partial ${name}`);
+	}
+	return handlebars.partials[name](this, opts);
+};

--- a/handlebars/load-partials.js
+++ b/handlebars/load-partials.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const Path = require('path');
+const path = require('path');
 const denodeify = require('denodeify');
 
 const readdirAsync = denodeify(fs.readdir);
@@ -25,7 +25,7 @@ const itemsWithStats = function (directory, limitToComponents) {
 						files = files.filter((f) => limitToComponents.indexOf(f) > -1);
 					}
 					const stats = files.map(function (file) {
-						const fullPath = Path.join(directory, file);
+						const fullPath = path.join(directory, file);
 
 						return lstatAsync(fullPath)
 							.then(function (stat) {
@@ -54,7 +54,7 @@ const classifyItems = function (items, otherPaths) {
 const selectValidLinkedPaths = function (linkedItems, ignores, linkPath) {
 	return linkedItems
 		.filter(function (item) { return ignores.indexOf(item.name) < 0 && item.stat.isDirectory(); })
-		.map(function (item) { return { name: Path.join(linkPath, item.name), path: item.path }; });
+		.map(function (item) { return { name: path.join(linkPath, item.name), path: item.path }; });
 };
 
 const itemNamespace = function (name, bowerRoot) {

--- a/handlebars/load-partials.js
+++ b/handlebars/load-partials.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const fs = require('fs');
+const Path = require('path');
+const denodeify = require('denodeify');
+
+const readdirAsync = denodeify(fs.readdir);
+const lstatAsync = denodeify(fs.lstat);
+const realpathAsync = denodeify(fs.realpath);
+const exists = denodeify(fs.exists, function (doesExists) { return [undefined, doesExists]; });
+
+const flatten = function (list) {
+	return list.reduce(function (acc, it) {
+		return acc.concat(it);
+	}, []);
+};
+
+const itemsWithStats = function (directory, limitToComponents) {
+	return exists(directory)
+		.then(function (exists) {
+			if (!exists) return [];
+			return readdirAsync(directory)
+				.then(function (files) {
+					if (limitToComponents) {
+						files = files.filter((f) => limitToComponents.indexOf(f) > -1);
+					}
+					const stats = files.map(function (file) {
+						const fullPath = Path.join(directory, file);
+
+						return lstatAsync(fullPath)
+							.then(function (stat) {
+								return {name: file, path: fullPath, stat: stat};
+							});
+					});
+
+					return Promise.all(stats);
+				});
+		});
+};
+
+const classifyItems = function (items, otherPaths) {
+	return ({
+		directories: items
+			.filter(function (it) { return it.stat.isDirectory(); })
+			.concat(otherPaths)
+			.map(function (it) { return { name: it.path || it, path: it.path || it }; }),
+
+		links: items
+			.filter(function (it) { return it.stat.isSymbolicLink(); })
+			.map(function (it) { return it.path; })
+	});
+};
+
+const selectValidLinkedPaths = function (linkedItems, ignores, linkPath) {
+	return linkedItems
+		.filter(function (item) { return ignores.indexOf(item.name) < 0 && item.stat.isDirectory(); })
+		.map(function (item) { return { name: Path.join(linkPath, item.name), path: item.path }; });
+};
+
+const itemNamespace = function (name, bowerRoot) {
+	const namespace = name.replace(bowerRoot, '');
+	if(namespace === name)
+		return '';
+
+	return namespace;
+};
+
+// exports
+
+const loadPartials = function (ehInstance, bowerRoot, otherPaths, ignores, limitToComponents) {
+	// Get files in bowerRoot
+	return itemsWithStats(bowerRoot, limitToComponents)
+		.then(function (items) {
+			items = classifyItems(items, otherPaths);
+
+			return Promise.all(items.links
+				.map(function (link) {
+					return realpathAsync(link)
+						.then(function (linkedPath) {
+							return itemsWithStats(linkedPath);
+						})
+						.then(function (it) {
+							return selectValidLinkedPaths(it, ignores, link);
+						});
+				})
+			)
+				.then(function (paths) {
+					return items.directories.concat(flatten(paths));
+				});
+		})
+		.then(function (directories) {
+			return Promise.all(directories.map(function (dir) {
+				const namespace = itemNamespace(dir.name, bowerRoot);
+
+				return ehInstance.getTemplates(dir.path)
+					.then(function (templates) {
+						return ({
+							templates: templates,
+							namespace: namespace
+						});
+					});
+			}));
+		});
+};
+
+module.exports = loadPartials;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const nExpress = require('@financial-times/n-express');
-const nHandlebars = require('@financial-times/n-handlebars');
+const extendedHandlebars = require('./handlebars/express-handlebars');
 const path = require('path');
 
 const handlebars = function ({app, directory, options}) {
@@ -15,7 +15,7 @@ const handlebars = function ({app, directory, options}) {
 		options.partialsDirectory.forEach(dir => partialsDir.push(dir));
 	}
 
-	return nHandlebars(app, {
+	return extendedHandlebars(app, {
 		partialsDir,
 		extname: options.extname || '.html',
 		defaultLayout: options.defaultLayout || false,

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-internal-tool#readme",
   "dependencies": {
-    "@financial-times/n-express": "^19.21.4",
-    "@financial-times/n-handlebars": "^2.0.0"
+    "@financial-times/n-express": "^19.21.4"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
This is part of the work needed to be done to [delete n-handlebars](https://financialtimes.atlassian.net/browse/CPP-60)

Most of the `n-handlebars logic` was migrated to this repo because most of the apps using the `n-internal-tool` depend on the extended helpers `n-handlebars` provided and also on the logic that optimized the loading of partials.

The ideal would've been to use `PageKitHandlebars`, but it does not support layouts which is a feature needed by other apps that use `n-internal-tool`.

I am open to looking into the possibility of migrating the apps that are using `n-internal-tool` to `PageKitHandlebars` and standalone `express`, so that we can archive this app.