### PR TITLE
CPP-60 remove n-handlebars error message

### DIFF
--- a/handlebars/express-handlebars.js
+++ b/handlebars/express-handlebars.js
@@ -8,7 +8,7 @@ const loadPartials = require('./load-partials');
 
 const nextifyHandlebars = function (options) {
 	if (!options || !options.directory) {
-		throw 'n-handlebars requires an options object containing a directory property';
+		throw 'n-internal-tool handlebars requires an options object containing a directory property';
 	}
 	const configuredHandlebars = handlebars({
 		helpers: options.helpers
@@ -47,7 +47,7 @@ const nextifyHandlebars = function (options) {
 
 const applyToExpress = function (app, options) {
 	if (!app) {
-		throw 'n-handlebars requires an instance of an express app';
+		throw 'n-internal-tool handlebars requires an instance of an express app';
 	}
 
 	return nextifyHandlebars(options)


### PR DESCRIPTION
removed an n-handlebars reference in an error message that was copied from n-handlebars

part of [n-handlebars removal work](https://financialtimes.atlassian.net/browse/CPP-60)